### PR TITLE
Update Solax-X3.json

### DIFF
--- a/data/regs/Solax-X3.json
+++ b/data/regs/Solax-X3.json
@@ -749,6 +749,28 @@
                     "datatype": "float",
                     "factor": 0.01,
                     "unit": "kWh"
+                },
+                {
+                    "position": [
+                        382,
+                        383
+                    ],
+                    "name": "CellVoltageHigh",
+                    "realname": "Cell Voltage High",
+                    "datatype": "float",
+                    "factor": 0.001,
+                    "unit": "V"
+                },
+                {
+                    "position": [
+                        384,
+                        385
+                    ],
+                    "name": "CellVoltageLow",
+                    "realname": "Cell Voltage Low",
+                    "datatype": "float",
+                    "factor": 0.001,
+                    "unit": "V"
                 }
             ],
             "id": [


### PR DESCRIPTION
try to add Cell_Voltage_High and Cell_Voltage_Low.

The test in the ModbusGateway works fine.
![Modbus_Gateway](https://github.com/tobiasfaust/SolaxModbusGateway/assets/5514433/3e651e59-c874-47a6-9e30-2720a6ad1a74)

The shown 3173 represents a voltage of Cell_Voltage_High of 3,173V.
Hope i changed the file correctly.

My WR is a Solax_Hybrid X3 G4.