### PR TITLE
Solax X3 GridPower, WiFi BSSID, longer mqtt_root

### DIFF
--- a/data/regs/Solax-X3.json
+++ b/data/regs/Solax-X3.json
@@ -47,6 +47,16 @@
         "data": {
             "livedata": [
                 {
+					"position": [
+                        7,
+                        8
+                    ],
+					"name": "GridPower",
+					"realname": "GridPower",
+					"datatype": "integer",
+					"unit": "W"
+				},
+                {
                     "position": [
                         215,
                         216

--- a/data/web/status.html
+++ b/data/web/status.html
@@ -40,6 +40,11 @@
         </tr>
 
         <tr>
+          <td>WiFi BSSID:</td>
+          <td><span id='bssid'></span></td>
+        </tr>
+
+        <tr>
           <td>MQTT Status:</td>
           <td><span id='mqtt_status'></span></td>
         </tr>

--- a/src/MyWebServer.cpp
+++ b/src/MyWebServer.cpp
@@ -324,6 +324,7 @@ void MyWebServer::GetInitDataStatus(AsyncResponseStream *response) {
   json["data"]["wifiname"] = (Config->GetUseETH()?"LAN":WiFi.SSID());
   json["data"]["macaddress"] = WiFi.macAddress();
   json["data"]["rssi"] = (Config->GetUseETH()?ETH.linkSpeed():WiFi.RSSI()), (Config->GetUseETH()?"Mbps":"");
+  json["data"]["bssid"] = (Config->GetUseETH()?"LAN":WiFi.BSSIDstr());
   json["data"]["mqtt_status"] = (mqtt->GetConnectStatusMqtt()?"Connected":"Not Connected");
   json["data"]["inverter_type"] = mb->GetInverterType();
   json["data"]["inverter_serial"] = mb->GetInverterSN();

--- a/src/modbus.cpp
+++ b/src/modbus.cpp
@@ -1005,7 +1005,7 @@ void modbus::GetLiveDataAsJson(AsyncResponseStream *response, String subaction) 
     count++;
   }
   
-  response->printf(" ]}, \"object_id\": \"%s/%s\"}", Config->GetMqttBasePath(), Config->GetMqttRoot());
+  response->printf(" ]}, \"object_id\": \"%s/%s\"}", Config->GetMqttBasePath().c_str(), Config->GetMqttRoot().c_str());
 }
 
 /*******************************************************


### PR DESCRIPTION
- [GetLiveDataAsJson: use c_str() to allow for longer names in mqtt_root](https://github.com/Obihoernchen80/SolaxModbusGateway/commit/6f3bd44cd333b915f7f2d889007d13963d7d7c73)
When I configure the mqtt_root to be e.g. "Solax123456789" the modbus item page fails (root cause being an invalid json response). I had no issues with the code from approx one year ago. The commit fixes that issue.

- [add to wifi BSSid to status](https://github.com/Obihoernchen80/SolaxModbusGateway/commit/ad6b54cef0404153f36d53692a09887ff6595746)
I have some wifi repeaters around, and sometimes the esp32 connects to a far away one and has a bad connection. The BSSID can be used to trace which access point is being used.

- [Solax-X3: add X1 GridPower register](https://github.com/Obihoernchen80/SolaxModbusGateway/commit/404117f6877a0645fdccf59a8b25c90f5caf469e)
The GridPower register is marked as "X1" in the X3 modbus documentation, however it *is* available on my QCells QVolt HYB-G3 (rebrand Solax X3)

- Also I would suggest to rethink having a seperate register file for the QCells QVolt HYB-G3 (called "QVolt HYP-G3.json") since it contains less registers and the Solax-X3 works just as well.