### PR TITLE
default mapping wenn er keinen Wert mappen kann

### DIFF
--- a/src/modbus.cpp
+++ b/src/modbus.cpp
@@ -830,6 +830,7 @@ void modbus::ParseData() {
 *******************************************************/
 String modbus::MapItem(JsonArray map, String value) {
   String ret = value;
+  bool match = false;
 
   for (JsonArray mapItem : map) {
     String v1 = mapItem[0].as<String>();
@@ -840,9 +841,23 @@ String modbus::MapItem(JsonArray map, String value) {
 
     if (value == v1) {
       ret = v2;
+      match = true;
       Config->log(4, "Mapped value: %s -> %s", v1.c_str(), v2.c_str());
     }
-  } 
+  }
+  if (!match) {
+    for (JsonArray mapItem : map) {
+      String v1 = mapItem[0].as<String>();
+      String v2 = mapItem[1].as<String>();
+
+      Config->log(5, "Check Map value: %s -> %s", v1.c_str(), v2.c_str());
+
+      if ("noMatch" == v1) {
+        ret = v2;
+        Config->log(4, "Mapped value: %s -> %s", v1.c_str(), v2.c_str());
+      }
+    }
+  }
   return ret;
 }
 

--- a/src/modbus.cpp
+++ b/src/modbus.cpp
@@ -846,13 +846,16 @@ String modbus::MapItem(JsonArray map, String value) {
     }
   }
   if (!match) {
+
+    String def = "noMatch";
+	  
     for (JsonArray mapItem : map) {
       String v1 = mapItem[0].as<String>();
       String v2 = mapItem[1].as<String>();
 
       Config->log(5, "Check Map value: %s -> %s", v1.c_str(), v2.c_str());
 
-      if ("noMatch" == v1) {
+      if (def == v1) {
         ret = v2;
         Config->log(4, "Mapped value: %s -> %s", v1.c_str(), v2.c_str());
       }


### PR DESCRIPTION
Ich hab für die Auswertung der Error Codes dass Problem, wenn mehr als ein Error ansteht kann er kein mapping mehr machen und was lesbares ausgeben, für denn fall wäre ein default mapping praktisch. 
Macht er aber nur wenn im Mapping das definiert ist 

[
              "noMatch",
              "Multiple Error"
]

Vielleicht willst du es übernehmen.

LG Lazgar