### PR TITLE
Change default pins for ESP32-C3 (fixes #148)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,6 @@
+Release 3.3.4:
+  -
+  
 Release 3.3.3:
   - improve logging functionality methods
   - fixing some bugs

--- a/include/_Release.h
+++ b/include/_Release.h
@@ -1,1 +1,1 @@
-#define Release "3.3.3"
+#define Release "3.3.4"

--- a/platformio.ini
+++ b/platformio.ini
@@ -67,3 +67,6 @@ board = esp32-s3-devkitc-1
 
 [env:firmware_ESP32-C3]
 board = esp32-c3-devkitm-1
+build_flags = ${env.build_flags}
+    -D DEFAULT_MODBUS_RX_PIN=6
+    -D DEFAULT_MODBUS_TX_PIN=7

--- a/src/baseconfig.cpp
+++ b/src/baseconfig.cpp
@@ -5,8 +5,8 @@
 #include <baseconfig.h>
 
 BaseConfig::BaseConfig(): debuglevel(2),
-                          serial_rx(3),
-                          serial_tx(1),
+                          serial_rx(RX),
+                          serial_tx(TX),
                           mqtt_UseRandomClientID(true),
                           useAuth(false) {
   #ifdef ESP8266
@@ -52,8 +52,8 @@ void BaseConfig::LoadJsonConfig() {
         if (doc["data"]["SelectConnectivity"]){if (strcmp(doc["data"]["SelectConnectivity"], "wifi")==0) { this->useETH=false;} else {this->useETH=true;}} else {this->useETH = false;}
         if (doc["data"]["debuglevel"])       { this->debuglevel = _max(doc["data"]["debuglevel"].as<uint8_t>(), 0);} else {this->debuglevel = 0; }
         if (doc["data"]["SelectLAN"])        { this->LANBoard = doc["data"]["SelectLAN"].as<String>();} else {this->LANBoard = "";}
-        if (doc["data"]["serial_rx"])        { this->serial_rx = doc["data"]["serial_rx"].as<uint8_t>(); } else {this->serial_rx = 3;}
-        if (doc["data"]["serial_tx"])        { this->serial_tx = doc["data"]["serial_tx"].as<uint8_t>(); } else {this->serial_tx = 1;}
+        if (doc["data"]["serial_rx"])        { this->serial_rx = doc["data"]["serial_rx"].as<uint8_t>(); } else {this->serial_rx = RX;}
+        if (doc["data"]["serial_tx"])        { this->serial_tx = doc["data"]["serial_tx"].as<uint8_t>(); } else {this->serial_tx = TX;}
         if (doc["data"]["auth_user"])        { this->auth_user = doc["data"]["auth_user"].as<String>();} else {this->auth_user = "admin";}
         if (doc["data"]["auth_pass"])        { this->auth_pass = doc["data"]["auth_pass"].as<String>();} else {this->auth_pass = "password";}
       

--- a/src/modbus.cpp
+++ b/src/modbus.cpp
@@ -42,8 +42,8 @@ modbus::modbus(): enableRelays(false),
     this->pin_Relay1 = this->default_pin_Relay1 = 12;
     this->pin_Relay2 = this->default_pin_Relay2 = 14;
   } else {
-    this->pin_RX = this->default_pin_RX = 16;
-    this->pin_TX = this->default_pin_TX = 17;
+    this->pin_RX = this->default_pin_RX = DEFAULT_MODBUS_RX_PIN;
+    this->pin_TX = this->default_pin_TX = DEFAULT_MODBUS_TX_PIN;
     this->pin_RTS = this->default_pin_RTS = 5;
     this->pin_Relay1 = this->default_pin_Relay1 = 18;
     this->pin_Relay2 = this->default_pin_Relay2 = 19;

--- a/src/modbus.h
+++ b/src/modbus.h
@@ -17,6 +17,14 @@
 #include <sstream>
 #include <openwb.h>
 
+#ifndef DEFAULT_MODBUS_RX_PIN
+#define DEFAULT_MODBUS_RX_PIN 16
+#endif
+
+#ifndef DEFAULT_MODBUS_TX_PIN
+#define DEFAULT_MODBUS_TX_PIN 17
+#endif
+
 //#define DEBUGMODE
 
 class modbus {


### PR DESCRIPTION
The UART2 pins on the ESP32 are used by the internal flash on the ESP32-C3, so make them configurable and set them correctly for the C3.

C3's default serial pins ([ref](https://docs.espressif.com/projects/esp-at/en/latest/esp32c3/Get_Started/Hardware_connection.html#id3)):
![image](https://github.com/user-attachments/assets/9b1e0417-54fa-4410-a049-652f465cd3e5)

And SPI flash ([ref, page 19](https://www.espressif.com/sites/default/files/documentation/esp32-c3_datasheet_en.pdf))
![image](https://github.com/user-attachments/assets/026fc5ba-1e22-40c9-8ce5-a9d54ec86d25)
